### PR TITLE
Remove redundant responseType from sendRequest

### DIFF
--- a/Sources/Authentication/AuthenticationHandler.swift
+++ b/Sources/Authentication/AuthenticationHandler.swift
@@ -233,7 +233,7 @@ extension AuthenticationHandler {
                 header: ["Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"],
                 body: body
             )
-            if let response = try await sendRequest(request: request, responseType: TokenModel.self) {
+            if let response: TokenModel = try await sendRequest(request: request) {
                 KeychainHelper.invalidateToken()
                 KeychainHelper.storeToken(response)
                 return response
@@ -259,7 +259,7 @@ extension AuthenticationHandler {
                 header: ["Content-Type": "application/json"],
                 body: automatedLoginModel.user.asJsonData
             )
-            if let response = try await sendRequest(request: request, responseType: TokenModel.self) {
+            if let response: TokenModel = try await sendRequest(request: request) {
                 KeychainHelper.invalidateToken()
 
                 KeychainHelper.storeToken(response)
@@ -285,7 +285,7 @@ extension AuthenticationHandler {
                 header: ["Authorization": "Bearer \(token.accessToken)"]
             )
 
-            if let response = try await sendRequest(request: request, responseType: UserModel.self) {
+            if let response: UserModel = try await sendRequest(request: request) {
                 return response
             } else {
                 throw CustomError.invalidData

--- a/Sources/Authentication/Helpers/NetworkHelper.swift
+++ b/Sources/Authentication/Helpers/NetworkHelper.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 extension AuthenticationHandler {
-    func sendRequest<Response: Codable>(request: URLRequest, responseType: Response.Type?) async throws -> Response? {
+    func sendRequest<Response: Codable>(request: URLRequest) async throws -> Response? {
         do {
             let (data, response) = try await URLSession.shared.data(for: request, delegate: nil)
             guard let response = response as? HTTPURLResponse else {
@@ -21,8 +21,7 @@ extension AuthenticationHandler {
                 } else {
                     let decoder = JSONDecoder()
                     decoder.keyDecodingStrategy = .convertFromSnakeCase
-                    guard let responseType = responseType,
-                          let decodedResponse = try? decoder.decode(responseType, from: data)
+                    guard let decodedResponse = try? decoder.decode(Response.self, from: data)
                     else {
                         throw CustomError.decodingError
                     }

--- a/Sources/Networking/Networking.swift
+++ b/Sources/Networking/Networking.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// NetworkingProtocol: This is where the method that executes the generic requests is located.
 public protocol NetworkingProtocol {
-    func sendRequest<Response: Codable>(request: URLRequest, responseType: Response.Type?) async throws -> Response?
+    func sendRequest<Response: Codable>(request: URLRequest) async throws -> Response?
 }
 
 
@@ -26,7 +26,7 @@ public final class Networking: NetworkingProtocol {
 
 public extension NetworkingProtocol {
     @discardableResult
-    func sendRequest<Response: Codable>(request: URLRequest, responseType: Response.Type?) async throws -> Response? {
+    func sendRequest<Response: Codable>(request: URLRequest) async throws -> Response? {
         do {
             let (data, response) = try await URLSession.shared.data(for: request, delegate: nil)
             guard let response = response as? HTTPURLResponse else {
@@ -41,8 +41,7 @@ public extension NetworkingProtocol {
                     let decoder = JSONDecoder()
                     // allows the conversion of the Date data type and adds a Z on the Date
                     decoder.dateDecodingStrategy = .iso8601
-                    guard let responseType = responseType,
-                          let decodedResponse = try? decoder.decode(responseType, from: data) else { throw NetworkingError.decodingError }
+                    guard let decodedResponse = try? decoder.decode(Response.self, from: data) else { throw NetworkingError.decodingError }
                     return decodedResponse
                 }
             case 401:


### PR DESCRIPTION
We are already using `Generic` in the `sendRequest` function and therefor we can discard the `responseType` parameter and use the provided `Generic` in the `decode` call.

This is a breaking change. We should decide if we want to keep a backward compatible function that contains a `responseType` parameter together with the new `sendRequest` function.